### PR TITLE
Update doctests

### DIFF
--- a/lib/simhash.ex
+++ b/lib/simhash.ex
@@ -124,7 +124,7 @@ defmodule Simhash do
   def n_grams(str, n \\ 3) do
     str
     |> String.graphemes()
-    |> Enum.chunk(n, 1)
+    |> Enum.chunk_every(n, 1, :discard)
     |> Enum.map(&Enum.join/1)
   end
 

--- a/lib/simhash.ex
+++ b/lib/simhash.ex
@@ -6,12 +6,16 @@ defmodule Simhash do
 
       iex> Simhash.similarity("Universal Avenue", "Universe Avenue")
       0.71875
+
       iex> Simhash.similarity("hocus pocus", "pocus hocus")
       0.8125
+
       iex> Simhash.similarity("Sankt Eriksgatan 1", "S:t Eriksgatan 1")
       0.8125
+
       iex> Simhash.similarity("Purple flowers", "Green grass")
       0.5625
+
       iex> Simhash.similarity("Peanut butter", "Strawberry cocktail")
       0.4375
 
@@ -20,8 +24,10 @@ defmodule Simhash do
 
       iex> Simhash.similarity("hocus pocus", "pocus hocus", 1)
       1.0
+
       iex> Simhash.similarity("Sankt Eriksgatan 1", "S:t Eriksgatan 1", 6)
       0.859375
+
       iex> Simhash.similarity("Purple flowers", "Green grass", 6)
       0.546875
 
@@ -127,6 +133,7 @@ defmodule Simhash do
 
       iex> Simhash.siphash("abc")
       <<249, 236, 145, 130, 66, 18, 3, 247>>
+
       iex> byte_size(Simhash.siphash("abc"))
       8
 

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Simhash.Mixfile do
   defp deps do
     [
       {:siphash, "~> 3.1.1"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.19.2", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,8 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "siphash": {:hex, :siphash, "3.1.1", "2a1ec36c483e467cf7f619b45b896fde2576cadcf475083fae30a1f44e59fa85", [:mix, :make], []}}
+%{
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.2", "6f4081ccd9ed081b6dc0bd5af97a41e87f5554de469e7d76025fba535180565f", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "siphash": {:hex, :siphash, "3.1.1", "2a1ec36c483e467cf7f619b45b896fde2576cadcf475083fae30a1f44e59fa85", [:mix, :make], []},
+}


### PR DESCRIPTION
Description:
To isolate doctests from one another to have one doctest 
only have one assertion we have to add a newline between
them. This PR does this while also replacing an old function

Changes:
- Replace `Enum.chunk/3` by `Enum.chunk_by/4`
- Separate doctests to isolate them from one other
- Update `ex_doc` dependency