### PR TITLE
Rewrite hamming_distance function to a 17x faster recursive version

### DIFF
--- a/lib/simhash.ex
+++ b/lib/simhash.ex
@@ -77,17 +77,17 @@ defmodule Simhash do
       2
 
   """
-  def hamming_distance(left, right) do
-    [left, right]
-    |> List.zip()
-    |> Enum.map(&xor/1)
-    |> Enum.sum()
+  def hamming_distance(left, right, acc \\ 0)
+
+  def hamming_distance([same | tl_left], [same | tl_right], acc) do
+    hamming_distance(tl_left, tl_right, acc)
   end
 
-  defp xor({1, 1}), do: 0
-  defp xor({1, 0}), do: 1
-  defp xor({0, 1}), do: 1
-  defp xor({0, 0}), do: 0
+  def hamming_distance([_ | tl_left], [_ | tl_right], acc) do
+    hamming_distance(tl_left, tl_right, acc + 1)
+  end
+
+  def hamming_distance([], [], acc), do: acc
 
   @doc """
   Reduce list of lists to list of integers, following vector addition.


### PR DESCRIPTION
Hi, 

Nice library!
I rewrote the hamming_distance function to a faster recursive one.
Below is the benchmark (the benchmark code is in my fork in the `bench_new_hamming` branch):
You can run it with `mix run bench/bench_hamming.exs` in that branch. 
```
Operating System: Linux
CPU Information: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
Number of Available Cores: 8
Available memory: 15.37 GB
Elixir 1.9.1
Erlang 22.0.7

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 14 s

Benchmarking hamming_distance...
Benchmarking hamming_distance2...

Name                        ips        average  deviation         median         99th %
hamming_distance2       11.61 K      0.0861 ms     ±0.92%      0.0860 ms      0.0897 ms
hamming_distance         0.69 K        1.45 ms    ±12.93%        1.32 ms        1.80 ms

Comparison: 
hamming_distance2       11.61 K
hamming_distance         0.69 K - 16.79x slower +1.36 ms
```